### PR TITLE
Rimuovi cookie policy

### DIFF
--- a/templates/stampo.htm
+++ b/templates/stampo.htm
@@ -16,27 +16,6 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js"
             integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1"
             crossorigin="anonymous"></script>
-    <link rel="stylesheet" type="text/css"
-          href="//cdnpub.websitepolicies.com/lib/cookieconsent/1.0.1/cookieconsent.min.css"/>
-    <link rel="stylesheet" type="text/css" href="//wpcc.io/lib/1.0.2/cookieconsent.min.css"/>
-    <script src="//wpcc.io/lib/1.0.2/cookieconsent.min.js"></script>
-    <script>window.addEventListener("load", function () {
-        window.wpcc.init({
-            "border": "thin",
-            "corners": "small",
-            "colors": {
-                "popup": {"background": "#606060", "text": "#ffffff", "border": "#f9f9f9"},
-                "button": {"background": "#f9f9f9", "text": "#000000"}
-            },
-            "position": "bottom",
-            "content": {
-                "href": "  https://www.websitepolicies.com/policies/view/ChODGXPr",
-                "message": "Questo sito utilizza cookie per erogare determinati servizi. Accertati di aver letto la cookie policy per proseguire.",
-                "link": "Scopri di più.",
-                "button": "Ho capito!"
-            }
-        })
-    });</script>
     {% block extrahead %}
     {% endblock %}
 </head>


### PR DESCRIPTION
Si risparmia fino a 1000ms di tempo di caricamento della pagina. (it's huge)

Tanto Erre2 non usa dei cookie per gli utenti normali, li usa solo per il login dell'amministratore...